### PR TITLE
feat: verify last build commit before calling gitDiff

### DIFF
--- a/changed-files/lib/git-diff.ts
+++ b/changed-files/lib/git-diff.ts
@@ -26,3 +26,11 @@ export async function gitDiff(from: string, to: string, { cwd, verbose }: { cwd?
         return true;
     });
 }
+
+export async function gitVerify(commitId: string, { cwd, verbose }: { cwd?: string; verbose?: boolean } = {}): Promise<boolean> {
+    if (verbose) {
+        console.log(`> Executing git verify-commit on ${commitId}`);
+    }
+
+    return 0 === await tl.exec("git", ["verify-commit", commitId], { cwd, ignoreReturnCode: true });
+}

--- a/changed-files/tests/01-base.runner.ts
+++ b/changed-files/tests/01-base.runner.ts
@@ -32,6 +32,7 @@ tmr.setAnswers({
         "/bin/git": true
     },
     exec: {
+        "/bin/git verify-commit latest_commit_id": { code: 0 },
         "/bin/git diff --name-only HEAD latest_commit_id .": {
             code: 0,
             stdout: "src/file1.ts\nsrc/file2.ts\ndocs/index.md"

--- a/changed-files/tests/04-no-glob-match.runner.ts
+++ b/changed-files/tests/04-no-glob-match.runner.ts
@@ -32,6 +32,7 @@ tmr.setAnswers({
         "/bin/git": true
     },
     exec: {
+        "/bin/git verify-commit latest_commit_id": { code: 0 },
         "/bin/git diff --name-only HEAD latest_commit_id .": {
             code: 0,
             stdout: "src/file1.ts\nsrc/file2.ts\ndocs/index.md"

--- a/changed-files/tests/06-invalid-source-version.runner.ts
+++ b/changed-files/tests/06-invalid-source-version.runner.ts
@@ -16,7 +16,7 @@ setVariable("System.AccessToken", ACCESS_TOKEN);
 setVariable("System.DefinitionId", DEFINITION_ID);
 setVariable("Build.SourceVersion", SOURCE_VERSION);
 
-tmr.setInput("rules", "src/**/*.ts");
+tmr.setInput("rules", "**");
 tmr.setInput("variable", "HasChanged");
 tmr.setInput("isOutput", "true");
 tmr.setInput("verbose", "true");
@@ -32,12 +32,11 @@ tmr.setAnswers({
         "/bin/git": true
     },
     exec: {
-        "/bin/git verify-commit latest_commit_id": { code: 0 },
-        "/bin/git diff --name-only HEAD latest_commit_id .": {
-            code: 0,
-            stdout: "src/file1.ts\nsrc/file2.ts\ndocs/index.md"
+        "/bin/git verify-commit latest_commit_id": {
+            code: -1,
+            stdout: "error: commit 'latest_commit_id' not found"
         }
-    }
+    },
 });
 
 mockTfsApi();

--- a/changed-files/tests/10-input-variable.runner.ts
+++ b/changed-files/tests/10-input-variable.runner.ts
@@ -32,6 +32,7 @@ tmr.setAnswers({
         "/bin/git": true
     },
     exec: {
+        "/bin/git verify-commit latest_commit_id": { code: 0 },
         "/bin/git diff --name-only HEAD latest_commit_id .": {
             code: 0,
             stdout: "src/file1.ts\nsrc/file2.ts\ndocs/index.md"

--- a/changed-files/tests/11-input-is-output.runner.ts
+++ b/changed-files/tests/11-input-is-output.runner.ts
@@ -32,6 +32,7 @@ tmr.setAnswers({
         "/bin/git": true
     },
     exec: {
+        "/bin/git verify-commit latest_commit_id": { code: 0 },
         "/bin/git diff --name-only HEAD latest_commit_id .": {
             code: 0,
             stdout: "src/file1.ts\nsrc/file2.ts\ndocs/index.md"

--- a/changed-files/tests/20-multi-with-default.runner.ts
+++ b/changed-files/tests/20-multi-with-default.runner.ts
@@ -39,6 +39,7 @@ tmr.setAnswers({
         "/bin/git": true
     },
     exec: {
+        "/bin/git verify-commit latest_commit_id": { code: 0 },
         "/bin/git diff --name-only HEAD latest_commit_id .": {
             code: 0,
             stdout: "src/file1.ts\nsrc/file2.ts\ndocs/index.md"

--- a/changed-files/tests/21-multi-without-default.runner.ts
+++ b/changed-files/tests/21-multi-without-default.runner.ts
@@ -40,6 +40,7 @@ tmr.setAnswers({
         "/bin/git": true
     },
     exec: {
+        "/bin/git verify-commit latest_commit_id": { code: 0 },
         "/bin/git diff --name-only HEAD latest_commit_id .": {
             code: 0,
             stdout: "src/file1.ts\nsrc/file2.ts\ndocs/index.md"

--- a/changed-files/tests/22-multi-filter-empty.runner.ts
+++ b/changed-files/tests/22-multi-filter-empty.runner.ts
@@ -39,6 +39,7 @@ tmr.setAnswers({
         "/bin/git": true
     },
     exec: {
+        "/bin/git verify-commit latest_commit_id": { code: 0 },
         "/bin/git diff --name-only HEAD latest_commit_id .": {
             code: 0,
             stdout: "src/file1.ts\nsrc/file2.ts\ndocs/index.md"

--- a/changed-files/tests/index.spec.ts
+++ b/changed-files/tests/index.spec.ts
@@ -11,7 +11,7 @@ describe("vsts-changed-files", () => {
 
             expect(tr.succeeded).toBe(true);
 
-            expect(tr.invokedToolCount).toBe(1);
+            expect(tr.invokedToolCount).toBe(2);
             expect(tr.warningIssues).toHaveLength(0);
             expect(tr.errorIssues).toHaveLength(0);
 
@@ -53,7 +53,7 @@ describe("vsts-changed-files", () => {
 
             expect(tr.succeeded).toBe(true);
 
-            expect(tr.invokedToolCount).toBe(1);
+            expect(tr.invokedToolCount).toBe(2);
             expect(tr.warningIssues).toHaveLength(0);
             expect(tr.errorIssues).toHaveLength(0);
 
@@ -63,6 +63,20 @@ describe("vsts-changed-files", () => {
 
         test("should return true if some glob match", () => {
             const tr = new ttm.MockTestRunner(path.join(__dirname, "05-glob-match.runner.js"));
+            tr.run();
+
+            expect(tr.succeeded).toBe(true);
+
+            expect(tr.invokedToolCount).toBe(2);
+            expect(tr.warningIssues).toHaveLength(0);
+            expect(tr.errorIssues).toHaveLength(0);
+
+            expect(tr.stdout).toContain("##vso[task.setvariable variable=HasChanged;isOutput=true;]true");
+            expect(tr.stderr).toBeFalsy();
+        });
+
+        test("should return true if previous build sourceVersion is invalid", () => {
+            const tr = new ttm.MockTestRunner(path.join(__dirname, "06-invalid-source-version.runner.js"));
             tr.run();
 
             expect(tr.succeeded).toBe(true);
@@ -85,7 +99,7 @@ describe("vsts-changed-files", () => {
 
             expect(tr.succeeded).toBe(true);
 
-            expect(tr.invokedToolCount).toBe(1);
+            expect(tr.invokedToolCount).toBe(2);
             expect(tr.warningIssues).toHaveLength(0);
             expect(tr.errorIssues).toHaveLength(0);
 
@@ -99,7 +113,7 @@ describe("vsts-changed-files", () => {
 
             expect(tr.succeeded).toBe(true);
 
-            expect(tr.invokedToolCount).toBe(1);
+            expect(tr.invokedToolCount).toBe(2);
             expect(tr.warningIssues).toHaveLength(0);
             expect(tr.errorIssues).toHaveLength(0);
 
@@ -117,7 +131,7 @@ describe("vsts-changed-files", () => {
 
             expect(tr.succeeded).toBe(true);
 
-            expect(tr.invokedToolCount).toBe(1);
+            expect(tr.invokedToolCount).toBe(2);
             expect(tr.warningIssues).toHaveLength(0);
             expect(tr.errorIssues).toHaveLength(0);
 
@@ -133,7 +147,7 @@ describe("vsts-changed-files", () => {
 
             expect(tr.succeeded).toBe(true);
 
-            expect(tr.invokedToolCount).toBe(1);
+            expect(tr.invokedToolCount).toBe(2);
             expect(tr.warningIssues).toHaveLength(0);
             expect(tr.errorIssues).toHaveLength(0);
 
@@ -152,7 +166,7 @@ describe("vsts-changed-files", () => {
 
             expect(tr.succeeded).toBe(true);
 
-            expect(tr.invokedToolCount).toBe(1);
+            expect(tr.invokedToolCount).toBe(2);
             expect(tr.warningIssues).toHaveLength(0);
             expect(tr.errorIssues).toHaveLength(0);
 


### PR DESCRIPTION
Calling `git verify-commit` on **latestBuild.sourceVersion** before using it with `git diff` allows to bypass (i.e. consider all files are changed) when git history is messed up and/or inaccessible (ex. after a `git push --force`).