### PR TITLE
Add support for missing auth information

### DIFF
--- a/changed-files/index.ts
+++ b/changed-files/index.ts
@@ -48,7 +48,8 @@ function createContext(): Context {
 
 async function initializeClient(): Promise<IBuildApi> {
     const orgUri = getVariable("System.TeamFoundationCollectionUri");
-    const accessToken = getVariable("System.AccessToken");
+    // Allow a missing AccessToken to default to an empty string to allow public API access
+    const accessToken = getVariable("System.AccessToken", "");
 
     return createClient(orgUri, accessToken);
 }

--- a/changed-files/lib/util.ts
+++ b/changed-files/lib/util.ts
@@ -1,10 +1,13 @@
 import * as tl from "azure-pipelines-task-lib/task";
 import * as tcm from "azure-pipelines-task-lib/taskcommand";
 
-export function getVariable(name: string): string {
+export function getVariable(name: string, default_: string | null = null): string {
     const val = tl.getVariable(name);
     if (!val) {
-        throw new Error(`Environement Error: This task requires "${name}" variable.`);
+        if (default_ != null) {
+            return default_
+        }
+        throw new Error(`Environment Error: This task requires "${name}" variable.`);
     }
 
     return val;


### PR DESCRIPTION
By default, Azure DevOps does not provide the AccessToken variable to builds from forks to avoid leaking secrets, but the API endpoint that ChangedFiles needs does not actually require privileged access for public repos (such as would have this kind of untrusted fork).

This PR simply provides a facility for providing an access token (accepted by the devops API) for the case where we need to access a public endpoint anonymously.