### PR TITLE
Fix node10 deprecated warning from azurepipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Use Node.js 10.x
+    - name: Use Node.js 18.x
       uses: actions/setup-node@v1
       with:
-        node-version: 10.x
+        node-version: 18.x
 
     - name: Install dependencies
       run: npm ci

--- a/changed-files/task.json
+++ b/changed-files/task.json
@@ -10,8 +10,8 @@
   "author": "Touchify",
   "version": {
     "Major": 1,
-    "Minor": 2,
-    "Patch": 3
+    "Minor": 3,
+    "Patch": 0
   },
   "instanceNameFormat": "Check changed files: $(variable)",
   "groups": [

--- a/changed-files/task.json
+++ b/changed-files/task.json
@@ -71,7 +71,7 @@
     }
   ],
   "execution": {
-    "Node10": {
+    "Node18": {
       "target": "index.js"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-changed-files",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": "Azure DevOps pipeline task to get changed files and run tasks according to those changes",
   "author": "Touchify (dev@touchify.co)",
   "license": "MIT",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1,
   "id": "vsts-changed-files",
-  "version": "1.2.3",
+  "version": "1.3",
   "name": "Changed files",
   "description": "Pipeline task to get changed files and run tasks according to those changes.",
   "publisher": "Touchify",


### PR DESCRIPTION
This PR will fix [issue ](https://github.com/touchifyapp/vsts-changed-files/issues/52) that was being highlighted in Azure pipelines. 
![image](https://github.com/user-attachments/assets/356b8673-dce8-4ea6-94b2-ca1b72b9469d)

Node version is updated from 10 to 18
Task version is updated from 1.2.3 to 1.3